### PR TITLE
Optimize frontend Docker build time

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,51 @@
-.next
+# Dependencies (rebuilt in container)
+node_modules/
+
+# Build output (rebuilt in container)
+.next/
+out/
+
+# Development files
 .env.development
+.env.local
+.env*.local
+
+# Testing
+__tests__/
+*.test.ts
+*.test.tsx
+*.spec.ts
+*.spec.tsx
+coverage/
+jest.config.ts
+
+# Version control
+.git/
+.gitignore
+
+# IDE and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Documentation
+README.md
+*.md
+docs/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files (not needed inside container)
+Dockerfile
+Dockerfile.dev
+docker-compose*.yaml
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,13 +8,16 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json package-lock.json* ./
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm install; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+# Using cache mounts for faster subsequent builds
+COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/root/.yarn \
+    --mount=type=cache,target=/root/.pnpm-store \
+    if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+    elif [ -f package-lock.json ]; then npm ci; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -26,22 +29,13 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-# Debug: Show Tailwind config and PostCSS config
-RUN echo "=== Tailwind Config ===" && cat tailwind.config.js | head -10 || cat tailwind.config.mjs | head -10 || echo "No tailwind config found"
-RUN echo "=== PostCSS Config ===" && cat postcss.config.js || cat postcss.config.mjs || echo "No postcss config found"
-
-# Build with debugging
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
-
-# Debug: Check if Tailwind compiled properly
-RUN echo "=== CSS Files Generated ===" && find .next -name "*.css"
-RUN echo "=== First CSS File Content ===" && find .next -name "*.css" | head -1 | xargs head -20
-RUN echo "=== Check for compiled Tailwind ===" && find .next -name "*.css" -exec grep -l "\.bg-primary\|\.flex" {} \; || echo "No compiled Tailwind found"
+# Build the application
+RUN --mount=type=cache,target=/root/.npm \
+    if [ -f yarn.lock ]; then yarn run build; \
+    elif [ -f package-lock.json ]; then npm run build; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
- Expand .dockerignore to exclude node_modules, tests, git files, docs, and other unnecessary files
- Use npm ci instead of npm install for faster, deterministic installs
- Remove debug RUN commands that added 6 extra layers
- Add BuildKit cache mounts for npm/yarn/pnpm to cache packages between builds
- Consolidate RUN commands to reduce image layers