### PR TITLE
Fix: serve live prices on every request instead of caching

### DIFF
--- a/frontend/src/app/internal/page.tsx
+++ b/frontend/src/app/internal/page.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import MainContent from './MainContent';
 
-// Tell Next.js this route is statically generated at build time
-export const dynamic = 'force-static';
+// Tell Next.js this route is dynamically rendered on every request
+export const dynamic = 'force-dynamic';
 
 const HomePage = async () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
 
   let prices = { gold18kt: 0, gold22kt: 0, gold24kt: 0, silver: 0 };
   try {
-    const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, { cache: 'force-cache' });
+    const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, { cache: 'no-store' });
     if (res.ok) {
       const data = await res.json();
       prices = {
@@ -25,7 +25,7 @@ const HomePage = async () => {
 
   let photos: string[] = [];
   try {
-    const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, { cache: 'force-cache' });
+    const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, { cache: 'no-store' });
     if (res.ok) photos = await res.json();
   } catch (e) {
     console.error('Build-time photo fetch failed (internal):', e);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import MainContent from './MainContent';
 
-// Tell Next.js this route is statically generated at build time
-export const dynamic = 'force-static';
+// Tell Next.js this route is dynamically rendered on every request
+export const dynamic = 'force-dynamic';
 
 const HomePage = async () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
@@ -11,7 +11,7 @@ const HomePage = async () => {
   let prices = { gold18kt: 0, gold22kt: 0, gold24kt: 0, silver: 0 };
   try {
     const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, {
-      cache: 'force-cache',
+      cache: 'no-store',
     });
     if (res.ok) {
       const data = await res.json();
@@ -30,7 +30,7 @@ const HomePage = async () => {
   let photos: string[] = [];
   try {
     const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, {
-      cache: 'force-cache',
+      cache: 'no-store',
     });
     if (res.ok) photos = await res.json();
   } catch (e) {


### PR DESCRIPTION
## Changes

- Changed `dynamic` export from `'force-static'` to `'force-dynamic'` in both `page.tsx` files to enable dynamic rendering on every request
- Updated fetch cache options from `'force-cache'` to `'no-store'` for metal price and photo endpoints to ensure fresh data is fetched on each request
- Updated comments to reflect dynamic rendering behavior

## Impact

Prices and photos will now be fetched fresh on every request instead of being cached at build time, ensuring users always see the latest information.