### PR TITLE
fix: make pages compatible with static export

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,10 +208,12 @@ jobs:
           # Pull latest static builder image
           sudo docker pull 263095946180.dkr.ecr.ap-south-1.amazonaws.com/gold-price-tracker-static-builder:latest
 
-          # Run the static builder — connects to python-backend over the ECS bridge network
+          # Run the static builder — uses host network so python-backend resolves to localhost
           sudo docker run --rm \
-            --network $(sudo docker inspect python-backend --format '{{ "{{" }}range $k,$v := .NetworkSettings.Networks{{ "}}" }}{{ "{{" }}$k{{ "}}" }}{{ "{{" }}end{{ "}}" }}') \
+            --network host \
+            --add-host python-backend:127.0.0.1 \
             -e CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} \
+            -e CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }} \
             263095946180.dkr.ecr.ap-south-1.amazonaws.com/gold-price-tracker-static-builder:latest
 
     - name: Stop EC2 instance

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment: production
-    permissions:
-      contents: write
 
     steps:
     - name: Checkout
@@ -216,7 +214,6 @@ jobs:
             --add-host python-backend:127.0.0.1 \
             -e CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} \
             -e CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }} \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             263095946180.dkr.ecr.ap-south-1.amazonaws.com/gold-price-tracker-static-builder:latest
 
     - name: Stop EC2 instance

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout
@@ -214,6 +216,7 @@ jobs:
             --add-host python-backend:127.0.0.1 \
             -e CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} \
             -e CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             263095946180.dkr.ecr.ap-south-1.amazonaws.com/gold-price-tracker-static-builder:latest
 
     - name: Stop EC2 instance

--- a/frontend/Dockerfile.static
+++ b/frontend/Dockerfile.static
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl git
 
 WORKDIR /app
 
@@ -20,4 +20,15 @@ CMD sh -c '\
   echo "Backend ready. Building static export..." && \
   STATIC_EXPORT=true BACKEND_URL=http://python-backend:8000 npm run build:static && \
   echo "Deploying to Cloudflare Pages..." && \
-  npx wrangler pages deploy out --project-name gold-price-tracker'
+  npx wrangler pages deploy out --project-name gold-price-tracker && \
+  echo "Deploying internal page to GitHub Pages..." && \
+  mkdir -p /tmp/gh-pages && \
+  cp -r out/internal/. /tmp/gh-pages/ && \
+  echo "internal.mjw.co.in" > /tmp/gh-pages/CNAME && \
+  cd /tmp/gh-pages && \
+  git init && \
+  git config user.email "github-actions@github.com" && \
+  git config user.name "GitHub Actions" && \
+  git add -A && \
+  git commit -m "Deploy internal page [skip ci]" && \
+  git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/shankar1093/gold-price-tracker.git HEAD:gh-pages'

--- a/frontend/Dockerfile.static
+++ b/frontend/Dockerfile.static
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache curl git
+RUN apk add --no-cache curl
 
 WORKDIR /app
 
@@ -19,16 +19,7 @@ CMD sh -c '\
   done && \
   echo "Backend ready. Building static export..." && \
   STATIC_EXPORT=true BACKEND_URL=http://python-backend:8000 npm run build:static && \
-  echo "Deploying to Cloudflare Pages..." && \
+  echo "Deploying main site to Cloudflare Pages..." && \
   npx wrangler pages deploy out --project-name gold-price-tracker && \
-  echo "Deploying internal page to GitHub Pages..." && \
-  mkdir -p /tmp/gh-pages && \
-  cp -r out/internal/. /tmp/gh-pages/ && \
-  echo "internal.mjw.co.in" > /tmp/gh-pages/CNAME && \
-  cd /tmp/gh-pages && \
-  git init && \
-  git config user.email "github-actions@github.com" && \
-  git config user.name "GitHub Actions" && \
-  git add -A && \
-  git commit -m "Deploy internal page [skip ci]" && \
-  git push --force https://x-access-token:${GITHUB_TOKEN}@github.com/shankar1093/gold-price-tracker.git HEAD:gh-pages'
+  echo "Deploying internal page to Cloudflare Pages..." && \
+  npx wrangler pages deploy out/internal --project-name gold-price-tracker-internal'

--- a/frontend/src/app/MainContent.tsx
+++ b/frontend/src/app/MainContent.tsx
@@ -44,7 +44,7 @@ const MainContent: React.FC<MainContentProps> = ({ gold18kt, gold22kt, gold24kt,
           </div>
 
           <p className="text-xs opacity-50 tracking-wide">
-            Prices per gram &nbsp;·&nbsp; Inclusive of GST
+            Prices per gram &nbsp;·&nbsp; Exclusive of GST
           </p>
         </div>
 

--- a/frontend/src/app/internal/page.tsx
+++ b/frontend/src/app/internal/page.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import MainContent from './MainContent';
 
-// Tell Next.js this route is dynamically rendered on every request
-export const dynamic = 'force-dynamic';
-
 const HomePage = async () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
 
   let prices = { gold18kt: 0, gold22kt: 0, gold24kt: 0, silver: 0 };
   try {
-    const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, { cache: 'no-store' });
+    const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, { cache: 'force-cache' });
     if (res.ok) {
       const data = await res.json();
       prices = {
@@ -25,7 +22,7 @@ const HomePage = async () => {
 
   let photos: string[] = [];
   try {
-    const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, { cache: 'no-store' });
+    const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, { cache: 'force-cache' });
     if (res.ok) photos = await res.json();
   } catch (e) {
     console.error('Build-time photo fetch failed (internal):', e);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import './globals.css';
 import Footer from '../components/footer';
 import Header from '../components/header';
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import MainContent from './MainContent';
 
-// Tell Next.js this route is dynamically rendered on every request
-export const dynamic = 'force-dynamic';
-
 const HomePage = async () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -11,7 +8,7 @@ const HomePage = async () => {
   let prices = { gold18kt: 0, gold22kt: 0, gold24kt: 0, silver: 0 };
   try {
     const res = await fetch(`${backendUrl}/gold_rate_admin/metal-rate/`, {
-      cache: 'no-store',
+      cache: 'force-cache',
     });
     if (res.ok) {
       const data = await res.json();
@@ -30,7 +27,7 @@ const HomePage = async () => {
   let photos: string[] = [];
   try {
     const res = await fetch(`${backendUrl}/gold_rate_admin/photos/`, {
-      cache: 'no-store',
+      cache: 'force-cache',
     });
     if (res.ok) photos = await res.json();
   } catch (e) {


### PR DESCRIPTION
## Summary
- Remove `force-dynamic` from `/` and `/internal` pages — incompatible with `output: export` static builds
- Change fetch `cache: 'no-store'` to `cache: 'force-cache'` so data is fetched once at build time and baked into the static HTML
- Add viewport meta tag to `layout.tsx` to fix ~10% size difference between static and SSR-deployed pages

## Test plan
- [ ] Build static export via Docker: `docker build --platform linux/amd64 -t gold-price-tracker-static -f frontend/Dockerfile.static frontend/`
- [ ] Confirm no `NEXT_STATIC_GEN_BAILOUT` errors during build
- [ ] Deploy to Cloudflare Pages and verify page renders at correct size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Changed the Text on the main screen to say Exclusive of tax instead of inclusive